### PR TITLE
同步组件更新组件的property属性

### DIFF
--- a/src/data/grid-column.vue
+++ b/src/data/grid-column.vue
@@ -189,6 +189,11 @@
         if (this.columnConfig) {
           this.columnConfig.label = newVal;
         }
+      },
+      property(newVal) {
+        if (this.columnConfig) {
+          this.columnConfig.property = newVal;
+        }
       }
     },
 


### PR DESCRIPTION
为表格序列排序时遇到的问题。

发现 grid-column组件的 property 属性改变时，并没有同步改变到this.columnConfig 中，造成父级组件grid中columns属性中的property还是原本值。从而影响排序。

@furybean 有劳龙哥合一下